### PR TITLE
Check if we are at the end of stream and set gameover=true

### DIFF
--- a/classes/storage/StorageCloudS3Stream.class.php
+++ b/classes/storage/StorageCloudS3Stream.class.php
@@ -72,6 +72,11 @@ class StorageCloudS3Stream
         }
 
         $this->offset += strlen($data);
+
+	if ($this->stream_eof()) {
+	   $this->gameOver = true;
+	}
+
         return $data;
     }
 


### PR DESCRIPTION
If we've already received enough data (= as much as there should be in this file), set gameover=true to fail future read requests for more data.